### PR TITLE
Reattach multiple frames at once

### DIFF
--- a/code.js
+++ b/code.js
@@ -7,6 +7,10 @@ function reattachInstance() {
     const clonedSelection = Object.assign([], figma.currentPage.selection);
     for (let index in clonedSelection) {
         let frame = clonedSelection[index];
+        if (frame.type !== "FRAME") {
+            skippedCount += 1;
+            continue;
+        }
         let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name);
         if (instanceReference != null) {
             let instanceClone = instanceReference.masterComponent.createInstance();

--- a/code.js
+++ b/code.js
@@ -1,6 +1,9 @@
 function reattachInstance() {
     let skippedCount = 0;
     let processedCount = 0;
+    if (figma.currentPage.selection.length == 0) {
+        return "Please, select a frame first";
+    }
     const clonedSelection = Object.assign([], figma.currentPage.selection);
     for (let index in clonedSelection) {
         let frame = clonedSelection[index];

--- a/code.js
+++ b/code.js
@@ -25,6 +25,6 @@ function reattachInstance() {
         skippedCount += 1;
         continue;
     }
-    return `${processedCount} frames processed, ${skippedCount} skipped`;
+    return `${processedCount} processed, ${skippedCount} skipped`;
 }
 figma.closePlugin(reattachInstance());

--- a/code.js
+++ b/code.js
@@ -1,19 +1,23 @@
 function reattachInstance() {
-    if (figma.currentPage.selection.length !== 1 || figma.currentPage.selection[0].type !== "FRAME") {
-        return "Please, select a frame first";
+    let skippedCount = 0;
+    let processedCount = 0;
+    const clonedSelection = Object.assign([], figma.currentPage.selection);
+    for (let index in clonedSelection) {
+        let frame = clonedSelection[index];
+        let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name);
+        if (instanceReference != null) {
+            let instanceClone = instanceReference.masterComponent.createInstance();
+            frame.parent.appendChild(instanceClone);
+            instanceClone.x = frame.x;
+            instanceClone.y = frame.y;
+            instanceClone.resize(frame.width, frame.height);
+            frame.remove();
+            processedCount += 1;
+            continue;
+        }
+        skippedCount += 1;
+        continue;
     }
-    const selectedFrame = figma.currentPage.selection[0];
-    const instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == selectedFrame.name);
-    if (instanceReference === null) {
-        return "Couldn't find an instance with the same frame name.";
-    }
-    let instanceClone = instanceReference.masterComponent.createInstance();
-    selectedFrame.parent.appendChild(instanceClone);
-    instanceClone.x = selectedFrame.x;
-    instanceClone.y = selectedFrame.y;
-    instanceClone.resize(selectedFrame.width, selectedFrame.height);
-    selectedFrame.remove();
-    figma.currentPage.selection = [instanceClone];
-    return `Frame replaced by "${instanceClone.name}" instance.`;
+    return `${processedCount} frames processed, ${skippedCount} skipped`;
 }
 figma.closePlugin(reattachInstance());

--- a/code.js
+++ b/code.js
@@ -1,17 +1,25 @@
 function reattachInstance() {
     let skippedCount = 0;
     let processedCount = 0;
+    let originalInstances = {};
     if (figma.currentPage.selection.length == 0) {
         return "Please, select a frame first";
     }
     const clonedSelection = Object.assign([], figma.currentPage.selection);
     for (let index in clonedSelection) {
         let frame = clonedSelection[index];
+        let instanceReference;
         if (frame.type !== "FRAME") {
             skippedCount += 1;
             continue;
         }
-        let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name);
+        if (!(frame.name in originalInstances)) {
+            instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name);
+            originalInstances[frame.name] = instanceReference;
+        }
+        else {
+            instanceReference = originalInstances[frame.name];
+        }
         if (instanceReference != null) {
             let instanceClone = instanceReference.masterComponent.createInstance();
             frame.parent.appendChild(instanceClone);

--- a/code.ts
+++ b/code.ts
@@ -1,6 +1,7 @@
 function reattachInstance() {
     let skippedCount = 0;
     let processedCount = 0;
+    let originalInstances = {};
 
     if (figma.currentPage.selection.length == 0) {
         return "Please, select a frame first";
@@ -10,13 +11,19 @@ function reattachInstance() {
 
     for (let index in clonedSelection) {
         let frame = clonedSelection[index];
+        let instanceReference;
 
         if (frame.type !== "FRAME") {
           skippedCount += 1;
           continue
         }
 
-        let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
+        if (!(frame.name in originalInstances)) {
+            instanceReference= figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
+            originalInstances[frame.name] = instanceReference;
+        } else {
+            instanceReference = originalInstances[frame.name];
+        }
 
         if (instanceReference != null) {
             let instanceClone = instanceReference.masterComponent.createInstance();

--- a/code.ts
+++ b/code.ts
@@ -1,29 +1,33 @@
 function reattachInstance() {
-  let skippedCount = 0;
-  let processedCount = 0;
+    let skippedCount = 0;
+    let processedCount = 0;
 
-  const clonedSelection = Object.assign([], figma.currentPage.selection);
-
-  for (let index in clonedSelection) {
-    let frame = clonedSelection[index];
-
-    let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
-
-    if (instanceReference != null) {
-      let instanceClone = instanceReference.masterComponent.createInstance();
-      frame.parent.appendChild(instanceClone);
-      instanceClone.x = frame.x;
-      instanceClone.y = frame.y;
-      instanceClone.resize(frame.width, frame.height);
-      frame.remove();
-      processedCount += 1;
-      continue;
+    if (figma.currentPage.selection.length == 0) {
+        return "Please, select a frame first";
     }
-    skippedCount += 1;
-    continue;
-  }
 
-  return `${processedCount} frames processed, ${skippedCount} skipped`;
+    const clonedSelection = Object.assign([], figma.currentPage.selection);
+
+    for (let index in clonedSelection) {
+        let frame = clonedSelection[index];
+
+        let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
+
+        if (instanceReference != null) {
+            let instanceClone = instanceReference.masterComponent.createInstance();
+            frame.parent.appendChild(instanceClone);
+            instanceClone.x = frame.x;
+            instanceClone.y = frame.y;
+            instanceClone.resize(frame.width, frame.height);
+            frame.remove();
+            processedCount += 1;
+            continue;
+        }
+        skippedCount += 1;
+        continue;
+    }
+
+    return `${processedCount} frames processed, ${skippedCount} skipped`;
 }
 
 figma.closePlugin(reattachInstance());

--- a/code.ts
+++ b/code.ts
@@ -32,7 +32,7 @@ function reattachInstance() {
         continue;
     }
 
-    return `${processedCount} frames processed, ${skippedCount} skipped`;
+    return `${processedCount} processed, ${skippedCount} skipped`;
 }
 
 figma.closePlugin(reattachInstance());

--- a/code.ts
+++ b/code.ts
@@ -11,6 +11,11 @@ function reattachInstance() {
     for (let index in clonedSelection) {
         let frame = clonedSelection[index];
 
+        if (frame.type !== "FRAME") {
+          skippedCount += 1;
+          continue
+        }
+
         let instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
 
         if (instanceReference != null) {


### PR DESCRIPTION
Thanks for your plugin, I had no idea that could be done.

I was sad about reattaching working only for one frame at once, so I make multiple frames at once. Frames could be different names, non-frames layers are skipped.

Here is a screencast: http://d.mikeozornin.ru/tNRhDJ

One problem — It work slowly for dozens of frames, I cannot understand why. I'm not a developer, so code can be somewhere bad :–)