### PR TITLE
Support also groups, not frames only

### DIFF
--- a/code.js
+++ b/code.js
@@ -6,10 +6,9 @@ function reattachInstance() {
         return "Please, select a frame first";
     }
     const clonedSelection = Object.assign([], figma.currentPage.selection);
-    for (let index in clonedSelection) {
-        let frame = clonedSelection[index];
+    for (let frame of clonedSelection) {
         let instanceReference;
-        if (frame.type !== "FRAME") {
+        if (frame.type !== "FRAME" && frame.type !== "GROUP") {
             skippedCount += 1;
             continue;
         }

--- a/code.js
+++ b/code.js
@@ -6,22 +6,21 @@ function reattachInstance() {
         return "Please, select a frame first";
     }
     const clonedSelection = Object.assign([], figma.currentPage.selection);
-    for (let index in clonedSelection) {
-        let frame = clonedSelection[index];
-        let instanceReference;
-        if (frame.type !== "FRAME") {
+    for (let frame of clonedSelection) {
+        let masterComponent;
+        if (frame.type !== "FRAME" && frame.type !== "GROUP") {
             skippedCount += 1;
             continue;
         }
         if (!(frame.name in originalInstances)) {
-            instanceReference = figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name);
-            originalInstances[frame.name] = instanceReference;
+            masterComponent = figma.root.findOne(node => node.type === "COMPONENT" && node.name == frame.name);
+            originalInstances[frame.name] = masterComponent;
         }
         else {
-            instanceReference = originalInstances[frame.name];
+            masterComponent = originalInstances[frame.name];
         }
-        if (instanceReference != null) {
-            let instanceClone = instanceReference.masterComponent.createInstance();
+        if (masterComponent != null) {
+            let instanceClone = masterComponent.createInstance();
             frame.parent.appendChild(instanceClone);
             instanceClone.x = frame.x;
             instanceClone.y = frame.y;

--- a/code.ts
+++ b/code.ts
@@ -9,24 +9,23 @@ function reattachInstance() {
 
     const clonedSelection = Object.assign([], figma.currentPage.selection);
 
-    for (let index in clonedSelection) {
-        let frame = clonedSelection[index];
-        let instanceReference;
+    for (let frame of clonedSelection) {
+        let masterComponent;
 
-        if (frame.type !== "FRAME") {
+        if (frame.type !== "FRAME" && frame.type !== "GROUP") {
           skippedCount += 1;
           continue
         }
 
         if (!(frame.name in originalInstances)) {
-            instanceReference= figma.currentPage.findOne(node => node.type === "INSTANCE" && node.name == frame.name) as InstanceNode;
-            originalInstances[frame.name] = instanceReference;
+            masterComponent= figma.root.findOne(node => node.type === "COMPONENT" && node.name == frame.name) as InstanceNode;
+            originalInstances[frame.name] = masterComponent;
         } else {
-            instanceReference = originalInstances[frame.name];
+            masterComponent = originalInstances[frame.name];
         }
 
-        if (instanceReference != null) {
-            let instanceClone = instanceReference.masterComponent.createInstance();
+        if (masterComponent != null) {
+            let instanceClone = masterComponent.createInstance();
             frame.parent.appendChild(instanceClone);
             instanceClone.x = frame.x;
             instanceClone.y = frame.y;

--- a/code.ts
+++ b/code.ts
@@ -9,11 +9,10 @@ function reattachInstance() {
 
     const clonedSelection = Object.assign([], figma.currentPage.selection);
 
-    for (let index in clonedSelection) {
-        let frame = clonedSelection[index];
+    for (let frame of clonedSelection) {
         let instanceReference;
 
-        if (frame.type !== "FRAME") {
+        if (frame.type !== "FRAME" && frame.type !== "GROUP") {
           skippedCount += 1;
           continue
         }


### PR DESCRIPTION
Sometimes I see in my files that ex-components became groups, not frames. So I made support for them too.

Upd: Also no need to have a component instance copy on a page. Plugin will find a master component and create its instance.